### PR TITLE
Allow policy controller access to secrets

### DIFF
--- a/stable/cluster-lifecycle/templates/klusterlet-addon-policyctrl-role.yaml
+++ b/stable/cluster-lifecycle/templates/klusterlet-addon-policyctrl-role.yaml
@@ -36,3 +36,11 @@ rules:
   - leases
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
for Issue: https://github.com/stolostron/backlog/issues/18708

Policy Controller on the managed-cluster now needs to be able sync secrets from the managed-cluster namespace on the Hub