### PR TITLE
Restrict access to the encryption-key secret resource only

### DIFF
--- a/stable/cluster-lifecycle/templates/klusterlet-addon-policyctrl-role.yaml
+++ b/stable/cluster-lifecycle/templates/klusterlet-addon-policyctrl-role.yaml
@@ -40,6 +40,8 @@ rules:
   - ""
   resources:
   - secrets
+  resourceNames:
+  - policy-encryption-key
   verbs:
   - get
   - list


### PR DESCRIPTION
Signed-off-by: Chaitanya Kandagatla <ckandaga@redhat.com>

Issue: stolostron/backlog#18708

Per discussion in the GRC team, restricting access to the specific encryption-key Secret.